### PR TITLE
Optimize by caching expensive call to getimagesize twice. Improvement of 3ms per request.

### DIFF
--- a/public_html/functions.php
+++ b/public_html/functions.php
@@ -33,7 +33,8 @@ function getBestImage($width, $height, $person)
         if(in_array(strtolower(pathinfo($file, PATHINFO_EXTENSION)), $allowed_file_types)){
             if (strpos($file, $dir) === false) $file = $dir . $file;
             if (is_file($file)) {
-                $aspect = getimagesize($file)[0]/getimagesize($file)[1];
+                $dimensions = getimagesize($file);
+                $aspect = $dimensions[0] / $dimensions[1];
                 $files_with_difference[] = array(
                     'file' => $file,
                     'aspect_difference' => abs($requestedAspect - $aspect)


### PR DESCRIPTION
Before:

$ ab -n 100 'http://placingbad.dev/123/123/walter'
Concurrency Level:      1
Time taken for tests:   20.764 seconds
Complete requests:      100
Failed requests:        0
Total transferred:      492400 bytes
HTML transferred:       468200 bytes
Requests per second:    4.82 [#/sec](mean)
Time per request:       207.639 [ms](mean)
Time per request:       207.639 [ms](mean, across all concurrent requests)

After:

$ ab -n 100 'http://placingbad.dev/123/123/walter'
Concurrency Level:      1
Time taken for tests:   20.425 seconds
Complete requests:      100
Failed requests:        0
Total transferred:      492400 bytes
HTML transferred:       468200 bytes
Requests per second:    4.90 [#/sec](mean)
Time per request:       204.251 [ms](mean)
Time per request:       204.251 [ms](mean, across all concurrent requests)
Transfer rate:          23.54 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:   202  204   2.3    204     210
Waiting:      202  204   2.3    203     210
Total:        202  204   2.3    204     210
