### PR TITLE
Optimize resizing process via caching: 204ms to 2ms response time.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .htaccess
 .ssh/*
 composer.phar
+/public_html/cache


### PR DESCRIPTION
Before:

$ ab -n 100 'http://placingbad.dev/123/123/walter'
Concurrency Level:      1
Time taken for tests:   20.425 seconds
Complete requests:      100
Failed requests:        0
Total transferred:      492400 bytes
HTML transferred:       468200 bytes
Requests per second:    4.90 [#/sec](mean)
Time per request:       204.251 [ms](mean)
Time per request:       204.251 [ms](mean, across all concurrent requests)
Transfer rate:          23.54 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:   202  204   2.3    204     210
Waiting:      202  204   2.3    203     210
Total:        202  204   2.3    204     210

After:

$ ab -n 100 'http://placingbad.dev/123/123/walter'
Concurrency Level:      1
Time taken for tests:   0.190 seconds
Complete requests:      100
Failed requests:        0
Total transferred:      491900 bytes
HTML transferred:       467700 bytes
Requests per second:    525.13 [#/sec](mean)
Time per request:       1.904 [ms](mean)
Time per request:       1.904 [ms](mean, across all concurrent requests)
Transfer rate:          2522.57 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:     2    2   0.2      2       3
Waiting:        2    2   0.2      2       3
Total:          2    2   0.2      2       3

Percentage of the requests served within a certain time (ms)
  50%      2
  66%      2
  75%      2
  80%      2
  90%      2
  95%      2
  98%      2
  99%      3
 100%      3 (longest request)
